### PR TITLE
verify docs automation

### DIFF
--- a/.github/workflows/commit_docs.yaml
+++ b/.github/workflows/commit_docs.yaml
@@ -59,8 +59,10 @@ jobs:
         if: success() || steps.create.conclusion == 'success' || steps.restore.conclusion == 'success'
         shell: bash
         run: |
+          # this requires relaxing of branch protection rules if pushing to develop
+          # else you can keep docs on a different branch
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add -A
-          git commit -a --no-verify -m "Add(htmldocs): CI automation"
+          git commit --no-verify -m "Add(htmldocs): CI automation"
           git push -f


### PR DESCRIPTION
theres still an issue where:
-  the github pages workflow occurs after the docs-commit workflow
- reduced the branch protection rules so we can commit directly to develop branch
  - this may not be an issue in production repos, as we could keep the deploy branch protection in place